### PR TITLE
Remove terraform provider max version contraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # terraform-enterprise-azure-credentials
+
+Note: Users of the module should implement maximum version constrains for the hashicorp/vault provider in their workspace if required. This module only implements a minimum version requirement to align with Terraform [best practices][tfverbp].
+
+[tfverbp]: https://developer.hashicorp.com/terraform/language/providers/requirements#best-practices-for-provider-versions

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     vault = {
       source  = "hashicorp/vault"
-      version = ">=3.2.1, <=3.4.0"
+      version = ">=3.2.1"
     }
   }
 }


### PR DESCRIPTION
Currently the module enforces a max version constraint which prevents consumers from resolving bugs or other issues without a module update. Additionally, Terraform [best practices](https://developer.hashicorp.com/terraform/language/providers/requirements#best-practices-for-provider-versions) guide against max version constraints outside of the root workspace.